### PR TITLE
Ferhan

### DIFF
--- a/src/dist/edu/umd/cloud9/collection/line/NumberTextDocuments.java
+++ b/src/dist/edu/umd/cloud9/collection/line/NumberTextDocuments.java
@@ -48,7 +48,7 @@ import org.apache.log4j.Logger;
  * </p>
  * 
  * 
- * @author Jimmy Lin
+ * @author Ferhan Ture
  */
 public class NumberTextDocuments extends Configured implements Tool {
 

--- a/src/dist/edu/umd/cloud9/collection/line/TextDocnoMapping.java
+++ b/src/dist/edu/umd/cloud9/collection/line/TextDocnoMapping.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -28,7 +27,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
-
 import edu.umd.cloud9.collection.DocnoMapping;
 import edu.umd.cloud9.util.FSLineReader;
 
@@ -39,7 +37,7 @@ import edu.umd.cloud9.util.FSLineReader;
  * </p>
 
  * 
- * @author Jimmy Lin
+ * @author Ferhan Ture
  */
 public class TextDocnoMapping implements DocnoMapping {
 


### PR DESCRIPTION
I added two classes under collections/line for support of a docno mapping with text collections. I tried this on a text collection Doug gave me few weeks ago to find duplicates, and it worked fine. 

With these classes, a text collection can be preprocessed via the class ivory/private/ivory.driver.PreprocessTextCollection.
