### PR TITLE
improved HMap increment support

### DIFF
--- a/src/dist/edu/umd/cloud9/util/map/HMapIF.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapIF.java
@@ -354,6 +354,23 @@ public class HMapIF implements MapIF, Cloneable, Serializable {
 		}
 	}
 
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
+  public void increment(int key, float value) {
+    if (this.containsKey(key)) {
+      this.put(key, (float) this.get(key) + value);
+    } else {
+      this.put(key, value);
+    }
+  }
+
 	// doc copied from interface
 	public float remove(int key) {
 		Entry e = removeEntryForKey(key);

--- a/src/dist/edu/umd/cloud9/util/map/HMapII.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapII.java
@@ -871,6 +871,15 @@ public class HMapII implements MapII, Cloneable, Serializable {
 		}
 	}
 	
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
 	public void increment(int key, int value) {
 		if (this.containsKey(key)) {
 			this.put(key, this.get(key) + value);

--- a/src/dist/edu/umd/cloud9/util/map/HMapIL.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapIL.java
@@ -878,6 +878,15 @@ public class HMapIL implements MapIL, Cloneable, Serializable {
 		}
 	}
 	
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
 	public void increment(int key, long value) {
 		if (this.containsKey(key)) {
 			this.put(key, (long) (this.get(key) + value));

--- a/src/dist/edu/umd/cloud9/util/map/HMapIS.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapIS.java
@@ -878,6 +878,15 @@ public class HMapIS implements MapIS, Cloneable, Serializable {
 		}
 	}
 	
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
 	public void increment(int key, short value) {
 		if (this.containsKey(key)) {
 			this.put(key, (short) (this.get(key) + value));

--- a/src/dist/edu/umd/cloud9/util/map/HMapKF.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapKF.java
@@ -401,6 +401,23 @@ public class HMapKF<K extends Comparable<?>> implements MapKF<K>, Cloneable, Ser
 		}
 	}
 
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
+  public void increment(K key, float value) {
+    if (this.containsKey(key)) {
+      this.put(key, (float) this.get(key) + value);
+    } else {
+      this.put(key, value);
+    }
+  }
+
 	// doc copied from interface
 	public float remove(K key) {
 		Entry<K> e = removeEntryForKey(key);

--- a/src/dist/edu/umd/cloud9/util/map/HMapKI.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapKI.java
@@ -893,6 +893,23 @@ public class HMapKI<K extends Comparable<?>> implements MapKI<K>, Cloneable, Ser
 		}
 	}
 
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
+  public void increment(K key, int value) {
+    if (this.containsKey(key)) {
+      this.put(key, this.get(key) + value);
+    } else {
+      this.put(key, value);
+    }
+  }
+
 	/**
 	 * Returns entries sorted by descending value. Ties broken by the key.
 	 * 

--- a/src/dist/edu/umd/cloud9/util/map/HMapKL.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapKL.java
@@ -248,6 +248,38 @@ public class HMapKL<K> implements MapKL<K>, Cloneable, Serializable {
 		return null;
 	}
 
+	 /**
+   * Increments the key. If the key does not exist in the map, its value is
+   * set to one.
+   * 
+   * @param key
+   *            key to increment
+   */
+  public void increment(K key) {
+    if (this.containsKey(key)) {
+      this.put(key, (long) this.get(key) + 1);
+    } else {
+      this.put(key, (long) 1);
+    }
+  }
+
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
+  public void increment(K key, long value) {
+    if (this.containsKey(key)) {
+      this.put(key, (long) this.get(key) + value);
+    } else {
+      this.put(key, value);
+    }
+  }
+
 	// doc copied from interface
 	public void put(K key, long value) {
 		if (key == null) {

--- a/src/dist/edu/umd/cloud9/util/map/HMapKS.java
+++ b/src/dist/edu/umd/cloud9/util/map/HMapKS.java
@@ -399,6 +399,38 @@ public class HMapKS<K> implements MapKS<K>, Cloneable, Serializable {
 		}
 	}
 
+	 /**
+   * Increments the key. If the key does not exist in the map, its value is
+   * set to one.
+   * 
+   * @param key
+   *            key to increment
+   */
+  public void increment(K key) {
+    if (this.containsKey(key)) {
+      this.put(key, (short) (this.get(key) + 1));
+    } else {
+      this.put(key, (short) 1);
+    }
+  }
+  
+  /**
+   * Increments the key by some value. If the key does not exist in the map, its value is
+   * set to the parameter value.
+   * 
+   * @param key
+   *            key to increment
+   * @param value
+   *            increment value
+   */
+  public void increment(K key, short value) {
+    if (this.containsKey(key)) {
+      this.put(key, (short) (this.get(key) + value));
+    } else {
+      this.put(key, value);
+    }
+  }
+
 	// doc copied from interface
 	public short remove(K key) {
 		Entry<K> e = removeEntryForKey(key);


### PR DESCRIPTION
I'm not sure if this is something you're interested in, but I added consistent support for incrementing the values of HMap{I,V}{F,I,L,S}s. The current code has inconsistent support for increment(key) and increment(key, value), with some HMaps supporting none, one, or both.
