### PR TITLE
Support for international language editions of Wikipedia

### DIFF
--- a/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaForwardIndex.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaForwardIndex.java
@@ -15,11 +15,13 @@ import org.apache.log4j.Logger;
 import com.google.common.base.Preconditions;
 
 import edu.umd.cloud9.collection.DocumentForwardIndex;
+import edu.umd.cloud9.collection.wikipedia.language.WikipediaPageFactory;
 
 /**
  * Forward index for Wikipedia collections.
  *
  * @author Jimmy Lin
+ * @author Peter Exner
  */
 public class WikipediaForwardIndex implements DocumentForwardIndex<WikipediaPage> {
   private static final Logger LOG = Logger.getLogger(WikipediaPage.class);
@@ -101,7 +103,7 @@ public class WikipediaForwardIndex implements DocumentForwardIndex<WikipediaPage
           SequenceFile.Reader.file(new Path(file)));
 
       IntWritable key = new IntWritable();
-      WikipediaPage value = new WikipediaPage();
+      WikipediaPage value = WikipediaPageFactory.createWikipediaPage(conf.get("wiki.language"));
 
       reader.seek(offsets[idx]);
 

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPage.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPage.java
@@ -36,8 +36,9 @@ import edu.umd.cloud9.collection.Indexable;
  * A page from Wikipedia.
  * 
  * @author Jimmy Lin
+ * @author Peter Exner
  */
-public class WikipediaPage extends Indexable {
+public abstract class WikipediaPage extends Indexable {
   /**
    * Start delimiter of the page, which is &lt;<code>page</code>&gt;.
    */
@@ -48,13 +49,55 @@ public class WikipediaPage extends Indexable {
    */
   public static final String XML_END_TAG = "</page>";
 
-  private String page;
-  private String title;
-  private String mId;
-  private int textStart;
-  private int textEnd;
-  private boolean isRedirect;
-  private boolean isStub;
+  /**
+   * Start delimiter of the title, which is &lt;<code>title</code>&gt;.
+   */
+  protected static final String XML_START_TAG_TITLE = "<title>";
+
+  /**
+   * End delimiter of the title, which is &lt;<code>/title</code>&gt;.
+   */
+  protected static final String XML_END_TAG_TITLE = "</title>";
+
+  /**
+   * Start delimiter of the namespace, which is &lt;<code>ns</code>&gt;.
+   */
+  protected static final String XML_START_TAG_NAMESPACE = "<ns>";
+
+  /**
+   * End delimiter of the namespace, which is &lt;<code>/ns</code>&gt;.
+   */
+  protected static final String XML_END_TAG_NAMESPACE = "</ns>";
+  
+  /**
+   * Start delimiter of the id, which is &lt;<code>id</code>&gt;.
+   */
+  protected static final String XML_START_TAG_ID = "<id>";
+
+  /**
+   * End delimiter of the id, which is &lt;<code>/id</code>&gt;.
+   */
+  protected static final String XML_END_TAG_ID = "</id>";
+
+  /**
+   * Start delimiter of the text, which is &lt;<code>text xml:space=\"preserve\"</code>&gt;.
+   */
+  protected static final String XML_START_TAG_TEXT = "<text xml:space=\"preserve\">";
+
+  /**
+   * End delimiter of the text, which is &lt;<code>/text</code>&gt;.
+   */
+  protected static final String XML_END_TAG_TEXT = "</text>";
+  
+  protected String page;
+  protected String title;
+  protected String mId;
+  protected int textStart;
+  protected int textEnd;
+  protected boolean isRedirect;
+  protected boolean isDisambig;
+  protected boolean isStub;
+  protected boolean isArticle;
   private String language;
 //  private String categories;
   private static final Map<String, Pattern> disambPattern = new HashMap<String, Pattern>();
@@ -106,6 +149,7 @@ public class WikipediaPage extends Indexable {
     return mId;
   }
 
+  @Deprecated
   public void setLanguage(String language) {
     this.language = language;
   }
@@ -204,7 +248,7 @@ public class WikipediaPage extends Indexable {
    * @return <code>true</code> if this page is a disambiguation page
    */
   public boolean isDisambiguation() {
-    return isDisambiguation("en");
+    return isDisambig;
   }
   
   /**
@@ -215,6 +259,7 @@ public class WikipediaPage extends Indexable {
    *    language of the Wikipedia page
    * @return <code>true</code> if this page is a disambiguation page
    */
+  @Deprecated
   public boolean isDisambiguation(String lang) {
     if (!disambPattern.containsKey(lang)) {
       lang = "en";    // default to English
@@ -257,16 +302,13 @@ public class WikipediaPage extends Indexable {
   }
 
   /**
-   * Checks to see if this page is an actual article, and not, for example,
+   * Checks to see if this page lives in the main/article namespace, and not, for example,
    * "File:", "Category:", "Wikipedia:", etc.
    *
    * @return <code>true</code> if this page is an actual article
    */
   public boolean isArticle() {
-    return !(getTitle().startsWith("File:") || getTitle().startsWith("Category:")
-        || getTitle().startsWith("Special:") || getTitle().startsWith("Wikipedia:")
-        || getTitle().startsWith("Wikipedia:") || getTitle().startsWith("Template:")
-        || getTitle().startsWith("Portal:"));
+    return isArticle;
   }
 
 
@@ -370,31 +412,15 @@ public class WikipediaPage extends Indexable {
    */
   public static void readPage(WikipediaPage page, String s) {
     page.page = s;
-
-    // parse out title
-    int start = s.indexOf("<title>");
-    int end = s.indexOf("</title>", start);
-    page.title = StringEscapeUtils.unescapeHtml(s.substring(start + 7, end));
-
-    start = s.indexOf("<id>");
-    end = s.indexOf("</id>");
-    page.mId = s.substring(start + 4, end);
-
-    // parse out actual text of article
-    page.textStart = s.indexOf("<text xml:space=\"preserve\">");
-    page.textEnd = s.indexOf("</text>", page.textStart);
-    
-//    int indexCategories = s.indexOf("wgCategories", page.textStart);
-//    if (indexCategories == -1) {
-//      page.categories = "";
-//    } else {
-//      int categoriesStart = s.indexOf("[", indexCategories);
-//      int categoriesEnd = s.indexOf("]", indexCategories);
-//      page.categories = categoriesStart == -1 ? "" : (categoriesEnd == -1 ? "" : s.substring(categoriesStart + 1, categoriesEnd));
-//    }
-    page.isRedirect = s.substring(page.textStart + 27, page.textStart + 36).compareTo("#REDIRECT") == 0 ||
-    s.substring(page.textStart + 27, page.textStart + 36).compareTo("#redirect") == 0;
-    page.isStub = s.indexOf("stub}}", page.textStart) != -1 || s.indexOf("Wikipedia:Stub") != -1;
+    page.processPage(s);
   }
 
+  /**
+   * Reads a raw XML string into a <code>WikipediaPage</code> object.
+   * Added for backwards compability.
+   * 
+   * @param s
+   *            raw XML string
+   */
+  protected abstract void processPage(String s);
 }

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPageInputFormat.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPageInputFormat.java
@@ -27,11 +27,13 @@ import org.apache.hadoop.mapred.Reporter;
 import edu.umd.cloud9.collection.IndexableFileInputFormatOld;
 import edu.umd.cloud9.collection.XMLInputFormatOld;
 import edu.umd.cloud9.collection.XMLInputFormatOld.XMLRecordReader;
+import edu.umd.cloud9.collection.wikipedia.language.WikipediaPageFactory;
 
 /**
  * Hadoop {@code InputFormat} for processing Wikipedia pages from the XML dumps.
  *
  * @author Jimmy Lin
+ * @author Peter Exner
  */
 public class WikipediaPageInputFormat extends IndexableFileInputFormatOld<LongWritable, WikipediaPage> {
 	/**
@@ -49,14 +51,16 @@ public class WikipediaPageInputFormat extends IndexableFileInputFormatOld<LongWr
 		private XMLRecordReader reader;
 		private Text text = new Text();
 		private LongWritable offset = new LongWritable();
-
+		private String language;
+		
 		/**
 		 * Creates a {@code WikipediaPageRecordReader}.
 		 */
 		public WikipediaPageRecordReader(FileSplit split, JobConf conf) throws IOException {
 			conf.set(XMLInputFormatOld.START_TAG_KEY, WikipediaPage.XML_START_TAG);
 			conf.set(XMLInputFormatOld.END_TAG_KEY, WikipediaPage.XML_END_TAG);
-
+			
+			language = conf.get("wiki.language");
 			reader = new XMLRecordReader(split, conf);
 		}
 
@@ -82,7 +86,7 @@ public class WikipediaPageInputFormat extends IndexableFileInputFormatOld<LongWr
 		 * Creates an object for the value.
 		 */
 		public WikipediaPage createValue() {
-			return new WikipediaPage();
+			return WikipediaPageFactory.createWikipediaPage(language);
 		}
 
 		/**

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPagesBz2InputStream.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/WikipediaPagesBz2InputStream.java
@@ -23,11 +23,15 @@ import java.io.InputStreamReader;
 
 import org.apache.tools.bzip2.CBZip2InputStream;
 
+import edu.umd.cloud9.collection.wikipedia.language.EnglishWikipediaPage;
+import edu.umd.cloud9.collection.wikipedia.language.WikipediaPageFactory;
+
 /**
  * Class for working with bz2-compressed Wikipedia article dump files on local
  * disk.
  * 
  * @author Jimmy Lin
+ * @author Peter Exner
  */
 public class WikipediaPagesBz2InputStream {
 	private static int DEFAULT_STRINGBUFFER_CAPACITY = 1024;
@@ -90,13 +94,13 @@ public class WikipediaPagesBz2InputStream {
 	}
 
 	public static void main(String[] args) throws Exception {
-		if (args.length != 1) {
-			System.err.println("usage: [file]");
+		if (args.length != 2) {
+			System.err.println("usage: [file] [language]");
 			System.exit(-1);
 		}
 
-		WikipediaPage p = new WikipediaPage();
-
+		WikipediaPage p = WikipediaPageFactory.createWikipediaPage(args[1]);
+		
 		WikipediaPagesBz2InputStream stream = new WikipediaPagesBz2InputStream(args[0]);
 		while (stream.readNext(p)) {
 			System.out.println(p.getContent());

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/language/EnglishWikipediaPage.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/language/EnglishWikipediaPage.java
@@ -1,0 +1,74 @@
+/*
+ * Cloud9: A MapReduce Library for Hadoop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package edu.umd.cloud9.collection.wikipedia.language;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import edu.umd.cloud9.collection.wikipedia.WikipediaPage;
+
+/**
+ * An English page from Wikipedia.
+ * 
+ * @author Peter Exner
+ */
+public class EnglishWikipediaPage extends WikipediaPage {
+  /**
+   * Language dependent identifiers of disambiguation, redirection, and stub pages.
+   */
+  private static final String IDENTIFIER_DISAMBIGUATION_UPPERCASE = "{{Disambig";
+  private static final String IDENTIFIER_DISAMBIGUATION_LOWERCASE = "{{disambig";
+  private static final String IDENTIFIER_REDIRECTION_UPPERCASE = "#REDIRECT";
+  private static final String IDENTIFIER_REDIRECTION_LOWERCASE = "#redirect";
+  private static final String IDENTIFIER_STUB_TEMPLATE = "stub}}";
+  private static final String IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE = "Wikipedia:Stub";
+  
+  /**
+   * Creates an empty <code>EnglishWikipediaPage</code> object.
+   */
+  public EnglishWikipediaPage() {
+    super();
+  }
+
+  @Override
+  protected void processPage(String s) {
+    // parse out title
+    int start = s.indexOf(XML_START_TAG_TITLE);
+    int end = s.indexOf(XML_END_TAG_TITLE, start);
+    this.title = StringEscapeUtils.unescapeHtml(s.substring(start + 7, end));
+
+    // determine if article belongs to the article namespace
+    start = s.indexOf(XML_START_TAG_NAMESPACE);
+    end = s.indexOf(XML_END_TAG_NAMESPACE);
+    this.isArticle = s.substring(start + 4, end).trim().equals("0");
+    
+    // parse out the document id
+    start = s.indexOf(XML_START_TAG_ID);
+    end = s.indexOf(XML_END_TAG_ID);
+    this.mId = s.substring(start + 4, end);
+
+    // parse out actual text of article
+    this.textStart = s.indexOf(XML_START_TAG_TEXT);
+    this.textEnd = s.indexOf(XML_END_TAG_TEXT, this.textStart);
+
+    // determine if article is a disambiguation, redirection, and/or stub page.
+    this.isDisambig = s.indexOf(IDENTIFIER_DISAMBIGUATION_LOWERCASE, this.textStart) != -1 || 
+                      s.indexOf(IDENTIFIER_DISAMBIGUATION_UPPERCASE, this.textStart) != -1;
+    this.isRedirect = s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_UPPERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_UPPERCASE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_LOWERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_LOWERCASE) == 0;
+    this.isStub = s.indexOf(IDENTIFIER_STUB_TEMPLATE, this.textStart) != -1 || 
+                  s.indexOf(IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE) != -1;
+  }
+}

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/language/GermanWikipediaPage.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/language/GermanWikipediaPage.java
@@ -1,0 +1,80 @@
+/*
+ * Cloud9: A MapReduce Library for Hadoop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package edu.umd.cloud9.collection.wikipedia.language;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import edu.umd.cloud9.collection.wikipedia.WikipediaPage;
+
+/**
+ * An English page from Wikipedia.
+ * 
+ * @author Peter Exner
+ */
+public class GermanWikipediaPage extends WikipediaPage {
+  /**
+   * Language dependent identifiers of disambiguation, redirection, and stub pages.
+   */
+  private static final String IDENTIFIER_DISAMBIGUATION_UPPERCASE_DE = "{{Begriffskl\u00E4rung";
+  private static final String IDENTIFIER_DISAMBIGUATION_LOWERCASE_DE = "{{begriffskl\u00E4rung";
+  private static final String IDENTIFIER_REDIRECTION_UPPERCASE = "#REDIRECT";
+  private static final String IDENTIFIER_REDIRECTION_LOWERCASE = "#redirect";
+  private static final String IDENTIFIER_REDIRECTION_UPPERCASE_DE = "#WEITERLEITUNG";
+  private static final String IDENTIFIER_REDIRECTION_LOWERCASE_DE = "#weiterleitung";
+  private static final String IDENTIFIER_REDIRECTION_CAPITALIZED_DE = "#Weiterleitung";
+  private static final String IDENTIFIER_STUB_TEMPLATE = "stub}}";
+  private static final String IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE = "Wikipedia:Stub";
+  
+  /**
+   * Creates an empty <code>EnglishWikipediaPage</code> object.
+   */
+  public GermanWikipediaPage() {
+    super();
+  }
+
+  @Override
+  protected void processPage(String s) {
+    // parse out title
+    int start = s.indexOf(XML_START_TAG_TITLE);
+    int end = s.indexOf(XML_END_TAG_TITLE, start);
+    this.title = StringEscapeUtils.unescapeHtml(s.substring(start + 7, end));
+
+    // determine if article belongs to the article namespace
+    start = s.indexOf(XML_START_TAG_NAMESPACE);
+    end = s.indexOf(XML_END_TAG_NAMESPACE);
+    this.isArticle = s.substring(start + 4, end).trim().equals("0");
+    
+    // parse out the document id
+    start = s.indexOf(XML_START_TAG_ID);
+    end = s.indexOf(XML_END_TAG_ID);
+    this.mId = s.substring(start + 4, end);
+
+    // parse out actual text of article
+    this.textStart = s.indexOf(XML_START_TAG_TEXT);
+    this.textEnd = s.indexOf(XML_END_TAG_TEXT, this.textStart);
+
+    // determine if article is a disambiguation, redirection, and/or stub page.
+    this.isDisambig = s.indexOf(IDENTIFIER_DISAMBIGUATION_LOWERCASE_DE, this.textStart) != -1 || 
+                      s.indexOf(IDENTIFIER_DISAMBIGUATION_UPPERCASE_DE, this.textStart) != -1;
+    this.isRedirect = s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_UPPERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_UPPERCASE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_LOWERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_LOWERCASE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_UPPERCASE_DE.length()).compareTo(IDENTIFIER_REDIRECTION_UPPERCASE_DE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_LOWERCASE_DE.length()).compareTo(IDENTIFIER_REDIRECTION_LOWERCASE_DE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_CAPITALIZED_DE.length()).compareTo(IDENTIFIER_REDIRECTION_CAPITALIZED_DE) == 0;
+    this.isStub = s.indexOf(IDENTIFIER_STUB_TEMPLATE, this.textStart) != -1 || 
+                  s.indexOf(IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE) != -1;
+  }
+}

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/language/SwedishWikipediaPage.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/language/SwedishWikipediaPage.java
@@ -1,0 +1,80 @@
+/*
+ * Cloud9: A MapReduce Library for Hadoop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package edu.umd.cloud9.collection.wikipedia.language;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import edu.umd.cloud9.collection.wikipedia.WikipediaPage;
+
+/**
+ * A Swedish page from Wikipedia.
+ * 
+ * @author Peter Exner
+ */
+public class SwedishWikipediaPage extends WikipediaPage {
+  /**
+   * Language dependent identifiers of disambiguation, redirection, and stub pages.
+   */
+  private static final String IDENTIFIER_DISAMBIGUATION_UPPERCASE_SV = "{{F\u00F6rgrening}}";
+  private static final String IDENTIFIER_DISAMBIGUATION_LOWERCASE_SV = "{{f\u00F6rgrening}}";
+  private static final String IDENTIFIER_REDIRECTION_UPPERCASE = "#REDIRECT";
+  private static final String IDENTIFIER_REDIRECTION_LOWERCASE = "#redirect";
+  private static final String IDENTIFIER_REDIRECTION_UPPERCASE_SV = "#OMDIRIGERING";
+  private static final String IDENTIFIER_REDIRECTION_LOWERCASE_SV = "#omdirigering";
+  private static final String IDENTIFIER_REDIRECTION_CAPITALIZED_SV = "#Omdirigering";
+  private static final String IDENTIFIER_STUB_TEMPLATE = "stub}}";
+  private static final String IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE = "Wikipedia:Stub";
+  
+  /**
+   * Creates an empty <code>EnglishWikipediaPage</code> object.
+   */
+  public SwedishWikipediaPage() {
+    super();
+  }
+
+  @Override
+  protected void processPage(String s) {
+    // parse out title
+    int start = s.indexOf(XML_START_TAG_TITLE);
+    int end = s.indexOf(XML_END_TAG_TITLE, start);
+    this.title = StringEscapeUtils.unescapeHtml(s.substring(start + 7, end));
+
+    // determine if article belongs to the article namespace
+    start = s.indexOf(XML_START_TAG_NAMESPACE);
+    end = s.indexOf(XML_END_TAG_NAMESPACE);
+    this.isArticle = s.substring(start + 4, end).trim().equals("0");
+    
+    // parse out the document id
+    start = s.indexOf(XML_START_TAG_ID);
+    end = s.indexOf(XML_END_TAG_ID);
+    this.mId = s.substring(start + 4, end);
+
+    // parse out actual text of article
+    this.textStart = s.indexOf(XML_START_TAG_TEXT);
+    this.textEnd = s.indexOf(XML_END_TAG_TEXT, this.textStart);
+
+    // determine if article is a disambiguation, redirection, and/or stub page.
+    this.isDisambig = s.indexOf(IDENTIFIER_DISAMBIGUATION_LOWERCASE_SV, this.textStart) != -1 || 
+                      s.indexOf(IDENTIFIER_DISAMBIGUATION_UPPERCASE_SV, this.textStart) != -1;
+    this.isRedirect = s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_UPPERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_UPPERCASE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_LOWERCASE.length()).compareTo(IDENTIFIER_REDIRECTION_LOWERCASE) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_UPPERCASE_SV.length()).compareTo(IDENTIFIER_REDIRECTION_UPPERCASE_SV) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_LOWERCASE_SV.length()).compareTo(IDENTIFIER_REDIRECTION_LOWERCASE_SV) == 0 ||
+                      s.substring(this.textStart + XML_START_TAG_TEXT.length(), this.textStart + XML_START_TAG_TEXT.length() + IDENTIFIER_REDIRECTION_CAPITALIZED_SV.length()).compareTo(IDENTIFIER_REDIRECTION_CAPITALIZED_SV) == 0;
+    this.isStub = s.indexOf(IDENTIFIER_STUB_TEMPLATE, this.textStart) != -1 || 
+                  s.indexOf(IDENTIFIER_STUB_WIKIPEDIA_NAMESPACE) != -1;
+  }
+}

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/language/WikipediaPageFactory.java
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/language/WikipediaPageFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Cloud9: A MapReduce Library for Hadoop
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package edu.umd.cloud9.collection.wikipedia.language;
+
+import java.util.regex.Pattern;
+
+import edu.umd.cloud9.collection.wikipedia.WikipediaPage;
+
+/**
+ * Hadoop {@code WikipediaPageFactory} for creating language dependent WikipediaPage Objects.
+ *
+ * @author Peter Exner
+ */
+public class WikipediaPageFactory {
+  
+  /**
+   * Returns a {@code WikipediaPage} for this {@code language}.
+   */
+  public static WikipediaPage createWikipediaPage(String language) {
+    if(language == null) {
+      return new EnglishWikipediaPage();
+    }
+    
+    if(language.equalsIgnoreCase("en")) {
+      return new EnglishWikipediaPage();
+    } else if(language.equalsIgnoreCase("sv")) {
+      return new SwedishWikipediaPage();
+    } else if(language.equalsIgnoreCase("de")) {
+      return new GermanWikipediaPage();
+    } else {
+      return new EnglishWikipediaPage();
+    }
+  }
+  
+  public static Class getWikipediaPageClass(String language) {
+    if(language == null) {
+      return EnglishWikipediaPage.class;
+    }
+    
+    if(language.equalsIgnoreCase("en")) {
+      return EnglishWikipediaPage.class;
+    } else if(language.equalsIgnoreCase("sv")) {
+      return SwedishWikipediaPage.class;
+    } else if(language.equalsIgnoreCase("de")) {
+      return GermanWikipediaPage.class;
+    } else {
+      return EnglishWikipediaPage.class;
+    }
+  }
+}

--- a/src/dist/edu/umd/cloud9/collection/wikipedia/language/package.html
+++ b/src/dist/edu/umd/cloud9/collection/wikipedia/language/package.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+</head>
+<body>
+
+<p>Provides language dependent classes for working with Wikipedia XML dumps.</p>
+
+</body>
+</html>


### PR DESCRIPTION
All language dependency has been moved to the wikipedia.language package.
Extensions to new languages can be added by creating a new language-specific class in the wikipedia.language package and registering it in the WikipediaPageFactory class.
