### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>commons-daemon</groupId>
+      <artifactId>commons-daemon</artifactId>
+      <version>1.0.9</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>fastutil</groupId>
       <artifactId>fastutil</artifactId>
       <version>5.1.5</version>


### PR DESCRIPTION
Added dependency for commons-daemon version 1.0.9
Without doing so ant was looking for http://repo1.maven.org/maven2/org/apache/commons/commons-daemon/1.0.3/commons-daemon-1.0.3.jar, which doesn't exist
