### PR TITLE
Added blocked compression support to XMLInputFormat

### DIFF
--- a/src/dist/edu/umd/cloud9/collection/XMLInputFormat.java
+++ b/src/dist/edu/umd/cloud9/collection/XMLInputFormat.java
@@ -116,10 +116,11 @@ public class XMLInputFormat extends TextInputFormat {
 
       FileSplit split = (FileSplit) input;
       start = split.getStart();
+      end = start + split.getLength();
       Path file = split.getPath();
 
       CompressionCodecFactory compressionCodecs = new CompressionCodecFactory(conf);
-      CompressionCodec codec = compressionCodecs.getCodec(file);
+      codec = compressionCodecs.getCodec(file);
 
       FileSystem fs = file.getFileSystem(conf);
 


### PR DESCRIPTION
With this change, one should be able to process a bzip2 directly. Let me know if you have any comment.
